### PR TITLE
check for reservation count in case there are issues with the api call

### DIFF
--- a/pkg/ec2/ec2.go
+++ b/pkg/ec2/ec2.go
@@ -100,6 +100,10 @@ func (a *AWSClient) CreateInstance(instance ec2v1alpha1.Instance) (status ec2v1a
 		return status, err
 	}
 
+	if len(reservation.Instances) == 0 {
+		return status, fmt.Errorf("no instance returned by aws api, likely issue with api call, retry again")
+	}
+
 	status.InstanceID = *reservation.Instances[0].InstanceId
 	status.PrivateIP = *reservation.Instances[0].PrivateIpAddress
 	status.Status = WaitForTag


### PR DESCRIPTION
Seen random failures due to issues with AWS API or AZ when its out of capacity.

No actual error is returned by the RunInstances API call.

This fix checks for Instances returned before it tries to update the status, and avoids the null pointer errors when the call fails without any valid error.